### PR TITLE
Report Limiting

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,11 +1,25 @@
 import mistletoe
 import os
 
+#Write report from markdown file `input_filename` to file stream `target`
+def WriteReport(target, input_filename):
+	target.write(f"<div id='{input_filename}'>")
+	with open(f"reports/{input_filename}") as input:
+		target.write(mistletoe.markdown(input))
+	target.write("</div>\n<br><hr><br>\n")
+	
+
 with open("output/index.html", "x") as out:
-    filelist = os.listdir("reports")
-    filelist.reverse()
-    for file in filelist:
-        out.write(f"<div id='{file}'>")
-        with open(f"reports/{file}") as input:
-            out.write(mistletoe.markdown(input))
-        out.write("</div>\n<br><hr><br>\n")
+    with open("output/index.html", "x") as out_all:
+        filelist = os.listdir("reports")
+		#We want the latest first, so it'll be the last alphabetically if numbered ascendingly
+        filelist.reverse()
+		
+        for index, file in enumerate(filelist):
+			#Only write the first three reports to the index file
+            if index < 3:
+				WriteReport(out, file)
+			
+			#Always write to the out_all file
+			WriteReport(out_all, file)
+			


### PR DESCRIPTION
Makes only the latest three reports show on index, shoves the rest to a subpage (all.html) for brevity reasons on the main site